### PR TITLE
pc - update codecov badge in README.md to point to s21 not w21

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # proj-ucsb-cs-las
 
-[![codecov](https://codecov.io/gh/ucsb-cs156-w21/proj-ucsb-cs-las/branch/main/graph/badge.svg)](https://codecov.io/gh/ucsb-cs156-w21/proj-ucsb-cs-las)
+[![codecov](https://codecov.io/gh/ucsb-cs156-s21/proj-ucsb-cs-las/branch/main/graph/badge.svg)](https://codecov.io/gh/ucsb-cs156-s21/proj-ucsb-cs-las)
 
 ## Purpose
 


### PR DESCRIPTION
In this PR, we update the codecov badge in the README.md to point to s21 instead of w21.

The codecov badge looks like this:

<img width="436" alt="image" src="https://user-images.githubusercontent.com/1119017/115975317-90149c00-a518-11eb-8509-63ed39ee636b.png">

And is produced by code like this in the README.md:

```
[![codecov](https://codecov.io/gh/ucsb-cs156-w21/proj-ucsb-cs-las/branch/main/graph/badge.svg)](https://codecov.io/gh/ucsb-cs156-w21/proj-ucsb-cs-las)
```

We updated `w21` to `s21` since the repo has been moved.