### PR TITLE
Staff s21 update codecov badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # proj-ucsb-cs-las
 
-[![codecov](https://codecov.io/gh/ucsb-cs156-w21/proj-ucsb-cs-las/branch/main/graph/badge.svg)](https://codecov.io/gh/ucsb-cs156-w21/proj-ucsb-cs-las)
+[![codecov](https://codecov.io/gh/ucsb-cs156-s21/proj-ucsb-cs-las/branch/main/graph/badge.svg)](https://codecov.io/gh/ucsb-cs156-s21/proj-ucsb-cs-las)
 
 ## Purpose
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # proj-ucsb-cs-las
 
-[![codecov](https://codecov.io/gh/ucsb-cs156-s21/proj-ucsb-cs-las/branch/main/graph/badge.svg)](https://codecov.io/gh/ucsb-cs156-s21/proj-ucsb-cs-las)
+[![codecov](https://codecov.io/gh/ucsb-cs156-s21/proj-ucsb-cs-las/branch/main/graph/badge.svg?token=poVZRDCYYn)](https://codecov.io/gh/ucsb-cs156-s21/proj-ucsb-cs-las)
 
 ## Purpose
 


### PR DESCRIPTION
In this PR, we update the codecov badge in the README.md to point to s21 instead of w21.

The codecov badge looks like this:

<img width="436" alt="image" src="https://user-images.githubusercontent.com/1119017/115975317-90149c00-a518-11eb-8509-63ed39ee636b.png">

And is produced by code like this in the README.md:

```markdown
[![codecov](https://codecov.io/gh/ucsb-cs156-w21/proj-ucsb-cs-las/branch/main/graph/badge.svg)](https://codecov.io/gh/ucsb-cs156-w21/proj-ucsb-cs-las)
```

We got the new Markdown by visiting: <https://app.codecov.io/gh/ucsb-cs156-s21/proj-ucsb-cs-las/settings/badge>

That looks like this:

```markdown
[![codecov](https://codecov.io/gh/ucsb-cs156-s21/proj-ucsb-cs-las/branch/main/graph/badge.svg?token=poVZRDCYYn)](https://codecov.io/gh/ucsb-cs156-s21/proj-ucsb-cs-las)
```

Note that the new Markdown has a token embedded in it, so it isn't sufficient to just update, say, `w21` to `s21`