### PR TITLE
rc/wp - 6pm-2 Add Swagger support to enable easier development of backend apis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,52 @@
 			<version>5.1</version>
 		</dependency>
 
+
+  <!-- added new stuff here-->
+		<!-- https://mvnrepository.com/artifact/javax.persistence/javax.persistence-api -->
+		<dependency>
+			<groupId>javax.persistence</groupId>
+			<artifactId>javax.persistence-api</artifactId>
+			<version>2.2</version>
+		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/org.springframework.data/spring-data-jpa -->
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-jpa</artifactId>
+			<version>2.3.5.RELEASE</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+			<version>2.3.5.RELEASE</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-mongodb</artifactId>
+		</dependency>
+		
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-csv</artifactId>
+			<version>1.8</version>
+		</dependency>
+
+		<!-- https://www.baeldung.com/swagger-2-documentation-for-spring-rest-api -->
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-boot-starter</artifactId>
+			<version>3.0.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-swagger-ui</artifactId>
+			<version>3.0.0</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/edu/ucsb/ucsbcslas/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/ucsbcslas/config/SecurityConfig.java
@@ -16,8 +16,13 @@ public class SecurityConfig extends ResourceServerConfigurerAdapter {
 
   @Override
   public void configure(HttpSecurity http) throws Exception {
-    http.authorizeRequests().mvcMatchers("/api/public/**").permitAll().mvcMatchers("/api/**")
-        .authenticated().anyRequest().permitAll();
+    http.authorizeRequests()
+    .mvcMatchers("/**").permitAll()
+    .mvcMatchers("/api/public/**").permitAll()
+    .mvcMatchers("/swagger-ui/**").permitAll()
+    .mvcMatchers("/api/docs").permitAll()
+    .mvcMatchers("/api/**")
+    .authenticated().anyRequest().permitAll();
   }
 
   @Override

--- a/src/main/java/edu/ucsb/ucsbcslas/config/SpringFoxConfig.java
+++ b/src/main/java/edu/ucsb/ucsbcslas/config/SpringFoxConfig.java
@@ -1,0 +1,30 @@
+package edu.ucsb.ucsbcslas.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+// import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+
+import static springfox.documentation.builders.PathSelectors.regex;
+
+
+/**
+ * Configuration for Swagger, a package that provides documentation
+ * for REST API endpoints.
+ * @see <a href="https://www.baeldung.com/swagger-2-documentation-for-spring-rest-api">https://www.baeldung.com/swagger-2-documentation-for-spring-rest-api</a>
+ */
+
+@Configuration
+public class SpringFoxConfig {                                    
+    @Bean
+    public Docket api() { 
+        return new Docket(DocumentationType.SWAGGER_2)
+          .select()              
+          .apis(RequestHandlerSelectors.any())    
+          .paths(regex("/api/.*"))                      
+          .build();                                           
+    }
+} 

--- a/src/main/java/edu/ucsb/ucsbcslas/controllers/ReactController.java
+++ b/src/main/java/edu/ucsb/ucsbcslas/controllers/ReactController.java
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
 public class ReactController {
-  @RequestMapping(value = {"/", "/{x:[\\w\\-]+}", "/{x:^(?!api$).*$}/**/{y:[\\w\\-]+}"})
+  @RequestMapping(value = {"/", "/{x:^(?!swagger-ui$)[\\w\\-]+}", "/{x:^(?!api$).*$}/**/{y:[\\w\\-]+}"})
   public String getIndex() {
     return "/index.html";
   }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+management.endpoints.web.exposure.include=mappings
+springfox.documentation.swagger.v2.path=/api/docs
 spring.config.location=classpath:/
 @environment-properties@
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL9Dialect


### PR DESCRIPTION
As a developer, I can use swagger-ui to access backend endpoint easily so that it is easier to do backend development.