### PR TITLE
6pm 2 add office hours list

### DIFF
--- a/javascript/src/main/components/OfficeHours/UpcomingOfficeHourTable.js
+++ b/javascript/src/main/components/OfficeHours/UpcomingOfficeHourTable.js
@@ -4,11 +4,9 @@ import { fetchWithToken } from "main/utils/fetch";
 import { useAuth0 } from "@auth0/auth0-react";
 import {asHumanQuarter} from "main/utils/quarter.ts"
 import BootstrapTable from 'react-bootstrap-table-next';
-import {useHistory} from "react-router-dom";
 
 
 export default ({officeHours}) => {
-    const history = useHistory();
     const { user, getAccessTokenSilently: getToken } = useAuth0();
     const { email } = user;
 
@@ -23,6 +21,7 @@ export default ({officeHours}) => {
         const quarter = row.tutorAssignment.course.quarter;
         return row.tutorAssignment.course.name + " " + asHumanQuarter(quarter);
     }
+    const renderEmail = (row) => row.tutorAssignment.tutor.email;
   
     const { data: roleInfo } = useSWR(
         ["/api/myRole", getToken],
@@ -62,7 +61,9 @@ export default ({officeHours}) => {
     if (isMember) {
         columns.push({
                 dataField: 'email',
-                text: 'email'
+                text: 'email',
+                formatter: (_cell, row) => renderEmail(row),
+                sortValue: (_cell, row) => renderEmail(row)
             }, {
                 dataField: 'zoomRoomLink',
                 text: 'Zoom Room',

--- a/javascript/src/main/components/OfficeHours/UpcomingOfficeHourTable.js
+++ b/javascript/src/main/components/OfficeHours/UpcomingOfficeHourTable.js
@@ -1,0 +1,69 @@
+import React from "react";
+import BootstrapTable from 'react-bootstrap-table-next';
+import { Button } from "react-bootstrap";
+
+
+export default ({officeHours,admin,deleteOfficeHour}) => {
+    const renderDeleteButton = (id) => {
+        return (
+            <Button variant="danger" data-testid="delete-button" onClick={() => deleteOfficeHour(id)}>Delete</Button>
+        )
+    }
+
+    function zoomRoomLinkFormatter(cell) {
+        return (
+            <div><a target="_blank" rel = "noopener noreferrer" href={cell}> { cell } </a></div>
+        );
+    }
+   
+    const columns = [{
+        dataField: 'id',
+        text: 'id',
+        sort: true
+    }, {
+        dataField: 'startTime',
+        text: 'Start Time',
+        sort: true
+    }, {
+        dataField: 'endTime',
+        text: 'End Time',
+        sort: true
+    }, {
+        dataField: 'dayOfWeek',
+        text: 'Day',
+        sort: true
+    }, {
+        dataField: 'zoomRoomLink',
+        text: 'Zoom Room',
+        formatter: zoomRoomLinkFormatter,
+        sort: true
+    }, {
+        dataField: 'notes',
+        text: 'Notes',
+        sort: true
+    }, {
+        dataField: 'tutorAssignment.id',
+        text: 'Tutor Assignment',
+        sort: true
+    }
+    ];
+
+    if (admin) {
+        columns.push({
+            text: "Delete",
+            isDummyField: true,
+            dataField: "delete",
+            formatter: (_cell, row) => renderDeleteButton(row.id)
+        });
+    }
+
+    return (
+        <BootstrapTable 
+            bootstrap4={true}
+            keyField='id' 
+            data={officeHours} 
+            columns={columns} 
+            striped 
+        />
+    );
+}

--- a/javascript/src/main/components/OfficeHours/UpcomingOfficeHourTable.js
+++ b/javascript/src/main/components/OfficeHours/UpcomingOfficeHourTable.js
@@ -1,11 +1,16 @@
 import React from "react";
 import useSWR from "swr";
 import { fetchWithToken } from "main/utils/fetch";
+import { useAuth0 } from "@auth0/auth0-react";
 import {asHumanQuarter} from "main/utils/quarter.ts"
 import BootstrapTable from 'react-bootstrap-table-next';
+import {useHistory} from "react-router-dom";
 
 
 export default ({officeHours}) => {
+    const history = useHistory();
+    const { user, getAccessTokenSilently: getToken } = useAuth0();
+    const { email } = user;
 
     function zoomRoomLinkFormatter(cell) {
         return (
@@ -23,7 +28,11 @@ export default ({officeHours}) => {
         ["/api/myRole", getToken],
         fetchWithToken
     );
-    const isMember = roleInfo && roleInfo.role && (roleInfo.role.toLowerCase() !== "guest" || roleInfo.role.toLowerCase() === "admin" || roleInfo.role.toLowerCase() === "member");
+    const { data: memberList } = useSWR(
+        [`/api/member/courses/forInstructor/${email}`, getToken],
+        fetchWithToken
+      );
+    const isMember = roleInfo && roleInfo.role && memberList && (memberList.length > 0 || roleInfo.role.toLowerCase() !== "guest" || roleInfo.role.toLowerCase() === "admin" || roleInfo.role.toLowerCase() === "member");
    
     const columns = [{
         dataField: 'id',

--- a/javascript/src/main/components/OfficeHours/UpcomingOfficeHourTable.js
+++ b/javascript/src/main/components/OfficeHours/UpcomingOfficeHourTable.js
@@ -1,4 +1,5 @@
 import React from "react";
+import {asHumanQuarter} from "main/utils/quarter.ts"
 import BootstrapTable from 'react-bootstrap-table-next';
 
 

--- a/javascript/src/main/components/OfficeHours/UpcomingOfficeHourTable.js
+++ b/javascript/src/main/components/OfficeHours/UpcomingOfficeHourTable.js
@@ -2,7 +2,7 @@ import React from "react";
 import BootstrapTable from 'react-bootstrap-table-next';
 
 
-export default ({upcomingOfficeHours}) => {
+export default ({upcomingOfficeHours, user}) => {
 
     function zoomRoomLinkFormatter(cell) {
         return (
@@ -44,7 +44,7 @@ export default ({upcomingOfficeHours}) => {
     },
     ];
 
-    if (admin) {
+    if (user) {
         columns.push({
                 dataField: 'email',
                 text: 'email'

--- a/javascript/src/main/components/OfficeHours/UpcomingOfficeHourTable.js
+++ b/javascript/src/main/components/OfficeHours/UpcomingOfficeHourTable.js
@@ -3,7 +3,7 @@ import {asHumanQuarter} from "main/utils/quarter.ts"
 import BootstrapTable from 'react-bootstrap-table-next';
 
 
-export default ({upcomingOfficeHours, user}) => {
+export default ({officeHours, user}) => {
 
     function zoomRoomLinkFormatter(cell) {
         return (
@@ -11,10 +11,10 @@ export default ({upcomingOfficeHours, user}) => {
         );
     }
 
-    const renderTutorName = (row) => row.tutor.firstName + " " + row.tutor.lastName;
+    const renderTutorName = (row) => row.tutorAssignment.tutor.firstName + " " + row.tutorAssignment.tutor.lastName;
     const renderCourseNameYear = (row) => {
-        const quarter = row.course.quarter;
-        return row.course.name + " " + asHumanQuarter(quarter);
+        const quarter = row.tutorAssignment.course.quarter;
+        return row.tutorAssignment.course.name + " " + asHumanQuarter(quarter);
     }
    
     const columns = [{
@@ -61,7 +61,7 @@ export default ({upcomingOfficeHours, user}) => {
         <BootstrapTable 
             bootstrap4={true}
             keyField='id' 
-            data={upcomingOfficeHours} 
+            data={officeHours} 
             columns={columns} 
             striped 
         />

--- a/javascript/src/main/components/OfficeHours/UpcomingOfficeHourTable.js
+++ b/javascript/src/main/components/OfficeHours/UpcomingOfficeHourTable.js
@@ -1,5 +1,8 @@
 import React from "react";
+import useSWR from "swr";
+import { fetchWithToken } from "main/utils/fetch";
 import {asHumanQuarter} from "main/utils/quarter.ts"
+import { useAuth0 } from "@auth0/auth0-react";
 import BootstrapTable from 'react-bootstrap-table-next';
 
 
@@ -16,6 +19,14 @@ export default ({officeHours, user}) => {
         const quarter = row.tutorAssignment.course.quarter;
         return row.tutorAssignment.course.name + " " + asHumanQuarter(quarter);
     }
+
+    const { user, getAccessTokenSilently: getToken } = useAuth0();
+  
+    const { data: roleInfo } = useSWR(
+        ["/api/myRole", getToken],
+        fetchWithToken
+    );
+    const isMember = roleInfo && roleInfo.role && (roleInfo.role.toLowerCase() !== "guest" || roleInfo.role.toLowerCase() === "admin" || roleInfo.role.toLowerCase() === "member");
    
     const columns = [{
         dataField: 'id',
@@ -35,9 +46,6 @@ export default ({officeHours, user}) => {
         formatter: (_cell, row) => renderTutorName(row),
         sortValue: (_cell, row) => renderTutorName(row)
     }, {
-        dataField: 'tutorID',
-        text: 'Tutor Assignment'
-    }, {
         dataField: 'courseNameYear',
         text: 'Course',
         formatter: (_cell, row) => renderCourseNameYear(row),
@@ -45,7 +53,7 @@ export default ({officeHours, user}) => {
     },
     ];
 
-    if (user) {
+    if (isMember) {
         columns.push({
                 dataField: 'email',
                 text: 'email'

--- a/javascript/src/main/components/OfficeHours/UpcomingOfficeHourTable.js
+++ b/javascript/src/main/components/OfficeHours/UpcomingOfficeHourTable.js
@@ -37,14 +37,14 @@ export default ({officeHours}) => {
         dataField: 'id',
         text: 'id'
     }, {
+        dataField: 'dayOfWeek',
+        text: 'Day'
+    }, {
         dataField: 'startTime',
         text: 'Start Time'
     }, {
         dataField: 'endTime',
         text: 'End Time'
-    }, {
-        dataField: 'dayOfWeek',
-        text: 'Day'
     }, {
         dataField: 'tutorName',
         text: 'Tutor',

--- a/javascript/src/main/components/OfficeHours/UpcomingOfficeHourTable.js
+++ b/javascript/src/main/components/OfficeHours/UpcomingOfficeHourTable.js
@@ -2,11 +2,10 @@ import React from "react";
 import useSWR from "swr";
 import { fetchWithToken } from "main/utils/fetch";
 import {asHumanQuarter} from "main/utils/quarter.ts"
-import { useAuth0 } from "@auth0/auth0-react";
 import BootstrapTable from 'react-bootstrap-table-next';
 
 
-export default ({officeHours, user}) => {
+export default ({officeHours}) => {
 
     function zoomRoomLinkFormatter(cell) {
         return (
@@ -19,8 +18,6 @@ export default ({officeHours, user}) => {
         const quarter = row.tutorAssignment.course.quarter;
         return row.tutorAssignment.course.name + " " + asHumanQuarter(quarter);
     }
-
-    const { user, getAccessTokenSilently: getToken } = useAuth0();
   
     const { data: roleInfo } = useSWR(
         ["/api/myRole", getToken],

--- a/javascript/src/main/components/OfficeHours/UpcomingOfficeHourTable.js
+++ b/javascript/src/main/components/OfficeHours/UpcomingOfficeHourTable.js
@@ -1,67 +1,66 @@
 import React from "react";
 import BootstrapTable from 'react-bootstrap-table-next';
-import { Button } from "react-bootstrap";
 
 
-export default ({officeHours,admin,deleteOfficeHour}) => {
-    const renderDeleteButton = (id) => {
-        return (
-            <Button variant="danger" data-testid="delete-button" onClick={() => deleteOfficeHour(id)}>Delete</Button>
-        )
-    }
+export default ({upcomingOfficeHours}) => {
 
     function zoomRoomLinkFormatter(cell) {
         return (
             <div><a target="_blank" rel = "noopener noreferrer" href={cell}> { cell } </a></div>
         );
     }
+
+    const renderTutorName = (row) => row.tutor.firstName + " " + row.tutor.lastName;
+    const renderCourseNameYear = (row) => {
+        const quarter = row.course.quarter;
+        return row.course.name + " " + asHumanQuarter(quarter);
+    }
    
     const columns = [{
         dataField: 'id',
-        text: 'id',
-        sort: true
+        text: 'id'
     }, {
         dataField: 'startTime',
-        text: 'Start Time',
-        sort: true
+        text: 'Start Time'
     }, {
         dataField: 'endTime',
-        text: 'End Time',
-        sort: true
+        text: 'End Time'
     }, {
         dataField: 'dayOfWeek',
-        text: 'Day',
-        sort: true
+        text: 'Day'
     }, {
-        dataField: 'zoomRoomLink',
-        text: 'Zoom Room',
-        formatter: zoomRoomLinkFormatter,
-        sort: true
+        dataField: 'tutorName',
+        text: 'Tutor',
+        formatter: (_cell, row) => renderTutorName(row),
+        sortValue: (_cell, row) => renderTutorName(row)
     }, {
-        dataField: 'notes',
-        text: 'Notes',
-        sort: true
+        dataField: 'tutorID',
+        text: 'Tutor Assignment'
     }, {
-        dataField: 'tutorAssignment.id',
-        text: 'Tutor Assignment',
-        sort: true
-    }
+        dataField: 'courseNameYear',
+        text: 'Course',
+        formatter: (_cell, row) => renderCourseNameYear(row),
+        sortValue: (_cell, row) => renderCourseNameYear(row)
+    },
     ];
 
     if (admin) {
         columns.push({
-            text: "Delete",
-            isDummyField: true,
-            dataField: "delete",
-            formatter: (_cell, row) => renderDeleteButton(row.id)
-        });
+                dataField: 'email',
+                text: 'email'
+            }, {
+                dataField: 'zoomRoomLink',
+                text: 'Zoom Room',
+                formatter: zoomRoomLinkFormatter
+            }
+        );
     }
 
     return (
         <BootstrapTable 
             bootstrap4={true}
             keyField='id' 
-            data={officeHours} 
+            data={upcomingOfficeHours} 
             columns={columns} 
             striped 
         />

--- a/javascript/src/main/pages/Home/Home.js
+++ b/javascript/src/main/pages/Home/Home.js
@@ -5,6 +5,7 @@ import UpcomingOfficeHourTable from "main/components/OfficeHours/UpcomingOfficeH
 import useSWR from "swr";
 import { fetchWithoutToken } from "main/utils/fetch";
 import fromFormat from "main/utils/FromFormat";
+import {useHistory} from "react-router-dom";
 
 const Home = () => {
     const { data: courses } = useSWR(
@@ -24,6 +25,20 @@ const Home = () => {
         }
         return <h5>All quarters are being viewed</h5>
     };
+    const history = useHistory();
+    const { getAccessTokenSilently: getToken } = useAuth0();
+    const { data: officeHourList, error, mutate: mutateOfficeHours } = useSWR(
+        ["/api/public/officeHours", getToken],
+        fetchWithToken
+    );
+    if (error) {
+        return (
+        <h1>We encountered an error; please reload the page and try again.</h1>
+        );
+    }
+    if (!officeHourList) {
+        return <Loading />;
+    }
 
     return (
         <Jumbotron>
@@ -35,7 +50,7 @@ const Home = () => {
             </div>
         </Jumbotron>,
         <>
-        <UpcomingOfficeHourTable officeHours={officeHours}/>
+        <UpcomingOfficeHourTable officeHours={officeHourList}/>
         </>
     );
 };

--- a/javascript/src/main/pages/Home/Home.js
+++ b/javascript/src/main/pages/Home/Home.js
@@ -8,7 +8,6 @@ import useSWR from "swr";
 import Loading from "main/components/Loading/Loading";
 import { fetchWithoutToken } from "main/utils/fetch";
 import fromFormat from "main/utils/FromFormat";
-import {useHistory} from "react-router-dom";
 
 const Home = () => {
     const { data: courses } = useSWR(
@@ -28,7 +27,6 @@ const Home = () => {
         }
         return <h5>All quarters are being viewed</h5>
     };
-    const history = useHistory();
     const { getAccessTokenSilently: getToken } = useAuth0();
     const { data: officeHourList, error, mutate: mutateOfficeHours } = useSWR(
         ["/api/public/officeHours", getToken],
@@ -52,9 +50,7 @@ const Home = () => {
                 <CourseList courses={courses || []} />
             </div>
         </Jumbotron>,
-        <>
         <UpcomingOfficeHourTable officeHours={officeHourList}/>
-        </>
     );
 };
 

--- a/javascript/src/main/pages/Home/Home.js
+++ b/javascript/src/main/pages/Home/Home.js
@@ -1,8 +1,11 @@
 import React from "react";
 import { Jumbotron } from "react-bootstrap";
+import { useAuth0 } from "@auth0/auth0-react";
 import CourseList from "main/components/Courses/CourseList";
+import { fetchWithToken } from "main/utils/fetch";
 import UpcomingOfficeHourTable from "main/components/OfficeHours/UpcomingOfficeHourTable";
 import useSWR from "swr";
+import Loading from "main/components/Loading/Loading";
 import { fetchWithoutToken } from "main/utils/fetch";
 import fromFormat from "main/utils/FromFormat";
 import {useHistory} from "react-router-dom";

--- a/javascript/src/main/pages/Home/Home.js
+++ b/javascript/src/main/pages/Home/Home.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Jumbotron } from "react-bootstrap";
 import CourseList from "main/components/Courses/CourseList";
-import UpcomingOfficeHourTable from "main/components/Courses/CourseList";
+import UpcomingOfficeHourTable from "main/components/OfficeHours/UpcomingOfficeHoursTable";
 import useSWR from "swr";
 import { fetchWithoutToken } from "main/utils/fetch";
 import fromFormat from "main/utils/FromFormat";

--- a/javascript/src/main/pages/Home/Home.js
+++ b/javascript/src/main/pages/Home/Home.js
@@ -32,7 +32,9 @@ const Home = () => {
                 {filterLabel(currentFilter)}
                 <CourseList courses={courses || []} />
             </div>
-        </Jumbotron>
+        </Jumbotron>,
+        <>
+        </>
     );
 };
 

--- a/javascript/src/main/pages/Home/Home.js
+++ b/javascript/src/main/pages/Home/Home.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Jumbotron } from "react-bootstrap";
 import CourseList from "main/components/Courses/CourseList";
-import UpcomingOfficeHourTable from "main/components/OfficeHours/UpcomingOfficeHoursTable";
+import UpcomingOfficeHourTable from "main/components/OfficeHours/UpcomingOfficeHourTable";
 import useSWR from "swr";
 import { fetchWithoutToken } from "main/utils/fetch";
 import fromFormat from "main/utils/FromFormat";

--- a/javascript/src/main/pages/Home/Home.js
+++ b/javascript/src/main/pages/Home/Home.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { Jumbotron } from "react-bootstrap";
-import CourseList from "main/components/Courses/CourseList"
+import CourseList from "main/components/Courses/CourseList";
+import UpcomingOfficeHourTable from "main/components/Courses/CourseList";
 import useSWR from "swr";
 import { fetchWithoutToken } from "main/utils/fetch";
 import fromFormat from "main/utils/FromFormat";
@@ -34,6 +35,7 @@ const Home = () => {
             </div>
         </Jumbotron>,
         <>
+        <UpcomingOfficeHourTable upcomingOfficeHours={upcomingOfficeHours}/>
         </>
     );
 };

--- a/javascript/src/main/pages/Home/Home.js
+++ b/javascript/src/main/pages/Home/Home.js
@@ -35,7 +35,7 @@ const Home = () => {
             </div>
         </Jumbotron>,
         <>
-        <UpcomingOfficeHourTable upcomingOfficeHours={upcomingOfficeHours}/>
+        <UpcomingOfficeHourTable officeHours={officeHours}/>
         </>
     );
 };

--- a/javascript/src/stories/components/OfficeHours/UpcomingTable.stories.js
+++ b/javascript/src/stories/components/OfficeHours/UpcomingTable.stories.js
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import UpcomingTable from "main/components/OfficeHours/UpcomingTable";
+
+export default {
+
+    title: 'components/OfficeHours/UpcomingTable',
+    component: UpcomingTable
+
+};
+
+const Template = args => <UpcomingTable {...args} />;
+
+// Empty (default) table
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+
+    courses: []
+
+};
+
+// Table with some courses and room slots listed
+
+export const Demo = Template.bind({});
+
+Demo.args = {
+
+
+
+};

--- a/javascript/src/stories/components/OfficeHours/UpcomingTable.stories.js
+++ b/javascript/src/stories/components/OfficeHours/UpcomingTable.stories.js
@@ -27,25 +27,29 @@ export const Demo = Template.bind({});
 
 Demo.args = {
 
-    /*
     courses: [
         {
-            name: "CMPSC 156",
             id: 1,
-            quarter: "F20",
-            instructorFirstName: "Phill",
-            instructorLastName: "Conrad",
-            instructorEmail: "phtcon@ucsb.edu",
+            startTime: "12:00PM",
+            endTime: "1:00PM",
+            dayOfWeek: "Monday",
+            tutorName: "Phill Conrad",
+            tutorID: "2",
+            courseNameYear: "CMPSC 156 Fall 2020",
+            email: "phtcon@ucsb.edu",
+            zoomRoomLink: "https://ucsb.zoom.us/j/12345678",
         },
         {
-            name: "CMPSC 148",
-            id: 2,
-            quarter: "F20",
-            instructorFirstName: "Chandra",
-            instructorLastName: "Krintz",
-            instructorEmail: "krintz@example.org",
+            id: 3,
+            startTime: "12:00PM",
+            endTime: "1:00PM",
+            dayOfWeek: "Monday",
+            tutorName: "Chandra Krintz",
+            tutorID: "4",
+            courseNameYear: "CMPSC 148 Fall 2020",
+            email: "krintz@exmaple.org",
+            zoomRoomLink: "https://ucsb.zoom.us/j/12345678",
         },
     ]
-    */
 
 };

--- a/javascript/src/stories/components/OfficeHours/UpcomingTable.stories.js
+++ b/javascript/src/stories/components/OfficeHours/UpcomingTable.stories.js
@@ -1,32 +1,51 @@
 import React from 'react';
 
-import UpcomingTable from "main/components/OfficeHours/UpcomingTable";
+import UpcomingOfficeHourTable from "main/components/OfficeHours/UpcomingOfficeHourTable";
 
 export default {
 
-    title: 'components/OfficeHours/UpcomingTable',
-    component: UpcomingTable
+    title: 'components/OfficeHours/UpcomingOfficeHourTable',
+    component: UpcomingOfficeHourTable
 
 };
 
-const Template = args => <UpcomingTable {...args} />;
+// template for office hour table
+const Template = args => <UpcomingOfficeHourTable {...args} />;
 
-// Empty (default) table
-
+// copy template as empty table
 export const Empty = Template.bind({});
 
 Empty.args = {
 
-    courses: []
+    courses: [],
+    roomslots: []
 
 };
 
-// Table with some courses and room slots listed
-
+// copy template with some dummy data
 export const Demo = Template.bind({});
 
 Demo.args = {
 
-
+    /*
+    courses: [
+        {
+            name: "CMPSC 156",
+            id: 1,
+            quarter: "F20",
+            instructorFirstName: "Phill",
+            instructorLastName: "Conrad",
+            instructorEmail: "phtcon@ucsb.edu",
+        },
+        {
+            name: "CMPSC 148",
+            id: 2,
+            quarter: "F20",
+            instructorFirstName: "Chandra",
+            instructorLastName: "Krintz",
+            instructorEmail: "krintz@example.org",
+        },
+    ]
+    */
 
 };


### PR DESCRIPTION
Table (based on office hours) has been implemented as well as storybook support. (untested)

However, it is not sorted by upcoming office hours. Also, due to referencing from office hours, an error message displays instead of the table when logged out. Additionally, courses table does not display in conjunction with upcoming office hours table.

There are no frontend tests implemented. No progress has been done with back end.

Suggest opening new issue to cover incomplete todos.