### PR TITLE
6pm-4-Fixed link issue on office hours where the link would go outside of the table (Remade PR)

### DIFF
--- a/javascript/src/main/components/OfficeHours/OfficeHourTable.js
+++ b/javascript/src/main/components/OfficeHours/OfficeHourTable.js
@@ -21,7 +21,7 @@ export default ({officeHours,admin,deleteOfficeHour}) => {
 
     function zoomRoomLinkFormatter(cell) {
         return (
-            <div><a target="_blank" rel = "noopener noreferrer" href={cell}> { cell } </a></div>
+            <div><a target="_blank" rel = "noopener noreferrer" href={cell}> Link </a></div>
         );
     }
 

--- a/javascript/src/test/components/OfficeHours/OfficeHourTable.test.js
+++ b/javascript/src/test/components/OfficeHours/OfficeHourTable.test.js
@@ -48,7 +48,7 @@ describe("OfficeHour table tests", () => {
   test("test Zoom Link Clickable", () => {
     const expectedLink = "test.zoom.com";
     const { getByText } = render(<OfficeHourTable officeHours = { testZoomLinkOfficeHour }/>);
-    const actual = getByText("test.zoom.com").closest('a').getAttribute("href");
+    const actual = getByText("Link").closest('a').getAttribute("href");
     expect(actual).toEqual(expectedLink);
   });
 


### PR DESCRIPTION
In this PR, I fixed the link issue on office hours where the link would go outside of the table. This PR had already been done before but due to merging conflicts, I dropped the branch and created a new branch from the fresh main. 